### PR TITLE
Add OOP version of task tracker

### DIFF
--- a/task-tracker-oop/README.md
+++ b/task-tracker-oop/README.md
@@ -1,0 +1,11 @@
+# Task Tracker OOP Version
+
+This directory contains a simple object-oriented rewrite of the Task Tracker example. It uses Bootstrap 5 for styling and organizes core functionality in PHP classes.
+
+## Setup
+
+1. Create a MySQL database `task_tracker` and import the schema from the original module (`task-tracker/schema.sql`).
+2. Adjust credentials in `inc/Database.php` if necessary.
+3. Place the folder on a PHP-enabled server and open `login.php` for the admin panel or `mobile_login.php` for user login.
+
+The MSG91 OTP integration is represented as a placeholder in `inc/Otp.php`.

--- a/task-tracker-oop/categories.php
+++ b/task-tracker-oop/categories.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__.'/inc/Category.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit();
+}
+$catModel = new Category();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = $_POST['title'];
+    $desc = $_POST['description'];
+    $catModel->create($title,$desc);
+}
+$categories = $catModel->all();
+include __DIR__.'/inc/header.php';
+?>
+<h3>Categories</h3>
+<table class="table table-bordered">
+<tr><th>Title</th><th>Description</th></tr>
+<?php foreach($categories as $c): ?>
+<tr><td><?= htmlspecialchars($c['title']) ?></td><td><?= htmlspecialchars($c['description']) ?></td></tr>
+<?php endforeach; ?>
+</table>
+<form method="post" class="mt-4">
+ <div class="mb-3">
+  <label class="form-label">Title</label>
+  <input type="text" name="title" class="form-control" required>
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Description</label>
+  <textarea name="description" class="form-control"></textarea>
+ </div>
+ <button class="btn btn-primary">Add Category</button>
+</form>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/dashboard.php
+++ b/task-tracker-oop/dashboard.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__.'/inc/User.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit();
+}
+include __DIR__.'/inc/header.php';
+?>
+<h2>Dashboard</h2>
+<p>Welcome to the admin dashboard.</p>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/inc/Category.php
+++ b/task-tracker-oop/inc/Category.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__.'/Database.php';
+
+class Category {
+    private $db;
+    public function __construct() {
+        $this->db = Database::getInstance()->getConnection();
+    }
+    public function all() {
+        $stmt = $this->db->query('SELECT * FROM categories ORDER BY title');
+        return $stmt->fetchAll();
+    }
+    public function find($id) {
+        $stmt = $this->db->prepare('SELECT * FROM categories WHERE id = ?');
+        $stmt->execute([$id]);
+        return $stmt->fetch();
+    }
+    public function create($title,$description) {
+        $stmt = $this->db->prepare('INSERT INTO categories (title, description) VALUES (?,?)');
+        $stmt->execute([$title,$description]);
+        return $this->db->lastInsertId();
+    }
+    public function update($id,$title,$description) {
+        $stmt = $this->db->prepare('UPDATE categories SET title=?, description=? WHERE id=?');
+        return $stmt->execute([$title,$description,$id]);
+    }
+    public function delete($id) {
+        $stmt = $this->db->prepare('DELETE FROM categories WHERE id=?');
+        return $stmt->execute([$id]);
+    }
+}
+?>

--- a/task-tracker-oop/inc/Comment.php
+++ b/task-tracker-oop/inc/Comment.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__.'/Database.php';
+
+class Comment {
+    private $db;
+    public function __construct() {
+        $this->db = Database::getInstance()->getConnection();
+    }
+    public function forTask($taskId) {
+        $stmt = $this->db->prepare('SELECT c.comment, c.created_at, u.name FROM task_comments c LEFT JOIN users u ON c.created_by = u.id WHERE c.task_id = ? ORDER BY c.created_at DESC');
+        $stmt->execute([$taskId]);
+        return $stmt->fetchAll();
+    }
+    public function add($taskId,$comment,$userId) {
+        $stmt = $this->db->prepare('INSERT INTO task_comments (task_id,comment,created_by,created_at) VALUES (?,?,?,NOW())');
+        return $stmt->execute([$taskId,$comment,$userId]);
+    }
+}
+?>

--- a/task-tracker-oop/inc/Database.php
+++ b/task-tracker-oop/inc/Database.php
@@ -1,0 +1,33 @@
+<?php
+class Database {
+    private static $instance = null;
+    private $pdo;
+
+    private function __construct() {
+        $host = 'localhost';
+        $db   = 'task_tracker';
+        $user = 'root';
+        $pass = '';
+        $charset = 'utf8mb4';
+
+        $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+        $this->pdo = new PDO($dsn, $user, $pass, $options);
+    }
+
+    public static function getInstance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function getConnection() {
+        return $this->pdo;
+    }
+}
+?>

--- a/task-tracker-oop/inc/Otp.php
+++ b/task-tracker-oop/inc/Otp.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__.'/Database.php';
+
+class Otp {
+    private $db;
+    public function __construct() {
+        $this->db = Database::getInstance()->getConnection();
+    }
+    public function send($mobile,$otp) {
+        // Placeholder for MSG91 OTP API integration
+        // Example: call MSG91 API to send the OTP
+        return true;
+    }
+    public function create($mobile,$otp) {
+        $stmt = $this->db->prepare('INSERT INTO otp_verification (mobile, otp, created_at) VALUES (?,?,NOW())');
+        $stmt->execute([$mobile,$otp]);
+    }
+    public function verify($mobile,$otp) {
+        $stmt = $this->db->prepare('SELECT id FROM otp_verification WHERE mobile=? AND otp=? AND created_at >= (NOW() - INTERVAL 10 MINUTE) ORDER BY id DESC LIMIT 1');
+        $stmt->execute([$mobile,$otp]);
+        $row = $stmt->fetch();
+        if ($row) {
+            $this->db->prepare('DELETE FROM otp_verification WHERE id=?')->execute([$row['id']]);
+            return true;
+        }
+        return false;
+    }
+}
+?>

--- a/task-tracker-oop/inc/Task.php
+++ b/task-tracker-oop/inc/Task.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__.'/Database.php';
+
+class Task {
+    private $db;
+    public function __construct() {
+        $this->db = Database::getInstance()->getConnection();
+    }
+    public function all() {
+        $stmt = $this->db->query('SELECT t.*, c.title AS category FROM tasks t LEFT JOIN categories c ON t.category_id = c.id ORDER BY t.updated_at DESC');
+        return $stmt->fetchAll();
+    }
+    public function userTasks($userId) {
+        $stmt = $this->db->prepare('SELECT t.*, c.title AS category FROM tasks t LEFT JOIN categories c ON t.category_id = c.id WHERE t.created_by = ? ORDER BY t.updated_at DESC');
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll();
+    }
+    public function find($id) {
+        $stmt = $this->db->prepare('SELECT t.*, c.title AS category FROM tasks t LEFT JOIN categories c ON t.category_id = c.id WHERE t.id = ?');
+        $stmt->execute([$id]);
+        return $stmt->fetch();
+    }
+    public function create($title,$description,$categoryId,$createdBy) {
+        $stmt = $this->db->prepare('INSERT INTO tasks (title,description,status,category_id,created_by,created_at) VALUES (?,?,?,?,?,NOW())');
+        $stmt->execute([$title,$description,'pending',$categoryId,$createdBy]);
+        return $this->db->lastInsertId();
+    }
+    public function updateStatus($id,$status) {
+        $stmt = $this->db->prepare('UPDATE tasks SET status=?, updated_at=NOW() WHERE id=?');
+        return $stmt->execute([$status,$id]);
+    }
+}
+?>

--- a/task-tracker-oop/inc/User.php
+++ b/task-tracker-oop/inc/User.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__.'/Database.php';
+
+class User {
+    private $db;
+
+    public function __construct() {
+        $this->db = Database::getInstance()->getConnection();
+    }
+
+    public function findByMobile($mobile) {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE mobile = ? LIMIT 1');
+        $stmt->execute([$mobile]);
+        return $stmt->fetch();
+    }
+
+    public function findById($id) {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE id = ?');
+        $stmt->execute([$id]);
+        return $stmt->fetch();
+    }
+
+    public function create($name, $mobile, $company, $isAdmin = 0) {
+        $stmt = $this->db->prepare('INSERT INTO users (name, mobile, company, is_admin_login, status, created_at) VALUES (?,?,?,?,1,NOW())');
+        $stmt->execute([$name, $mobile, $company, $isAdmin]);
+        return $this->db->lastInsertId();
+    }
+}
+?>

--- a/task-tracker-oop/inc/footer.php
+++ b/task-tracker-oop/inc/footer.php
@@ -1,0 +1,4 @@
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/task-tracker-oop/inc/header.php
+++ b/task-tracker-oop/inc/header.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <title>Task Tracker</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="dashboard.php">Task Tracker</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="tasks.php">Tasks</a></li>
+        <li class="nav-item"><a class="nav-link" href="categories.php">Categories</a></li>
+        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">

--- a/task-tracker-oop/index.php
+++ b/task-tracker-oop/index.php
@@ -1,0 +1,2 @@
+<?php
+header('Location: login.php');

--- a/task-tracker-oop/login.php
+++ b/task-tracker-oop/login.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__.'/inc/User.php';
+
+$userModel = new User();
+$err = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $mobile = $_POST['mobile'];
+    $user = $userModel->findByMobile($mobile);
+    if ($user && $user['is_admin_login']) {
+        $_SESSION['admin_id'] = $user['id'];
+        header('Location: dashboard.php');
+        exit();
+    } else {
+        $err = 'Invalid admin mobile';
+    }
+}
+include __DIR__.'/inc/header.php';
+?>
+<div class="row justify-content-center">
+ <div class="col-md-4">
+  <h3 class="mb-3">Admin Login</h3>
+  <?php if ($err): ?><div class="alert alert-danger"><?= htmlspecialchars($err) ?></div><?php endif; ?>
+  <form method="post">
+   <div class="mb-3">
+    <label class="form-label">Mobile</label>
+    <input type="text" name="mobile" class="form-control" required>
+   </div>
+   <button class="btn btn-primary">Login</button>
+  </form>
+ </div>
+</div>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/logout.php
+++ b/task-tracker-oop/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');

--- a/task-tracker-oop/mobile_login.php
+++ b/task-tracker-oop/mobile_login.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__.'/inc/User.php';
+require_once __DIR__.'/inc/Otp.php';
+$err = '';
+$step = 1;
+$otpModel = new Otp();
+$userModel = new User();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['mobile']) && !isset($_POST['otp'])) {
+        $mobile = $_POST['mobile'];
+        $otp = rand(100000,999999);
+        $otpModel->create($mobile,$otp);
+        $otpModel->send($mobile,$otp);
+        $step = 2;
+    } elseif (isset($_POST['otp'])) {
+        $mobile = $_POST['mobile_hidden'];
+        if ($otpModel->verify($mobile,$_POST['otp'])) {
+            $user = $userModel->findByMobile($mobile);
+            if (!$user) {
+                $userId = $userModel->create($mobile,$mobile,'');
+            } else {
+                $userId = $user['id'];
+            }
+            $_SESSION['user_id'] = $userId;
+            header('Location: tasks_list.php');
+            exit();
+        } else {
+            $err = 'Invalid OTP';
+            $step = 2;
+        }
+    }
+}
+include __DIR__.'/inc/header.php';
+?>
+<div class="row justify-content-center">
+ <div class="col-md-4">
+  <h3 class="mb-3">User Login</h3>
+  <?php if($err): ?><div class="alert alert-danger"><?= htmlspecialchars($err) ?></div><?php endif; ?>
+  <?php if ($step==1): ?>
+  <form method="post">
+   <div class="mb-3">
+    <label class="form-label">Mobile</label>
+    <input type="text" name="mobile" class="form-control" required>
+   </div>
+   <button class="btn btn-primary">Send OTP</button>
+  </form>
+  <?php else: ?>
+  <form method="post">
+   <input type="hidden" name="mobile_hidden" value="<?= htmlspecialchars($mobile) ?>">
+   <div class="mb-3">
+    <label class="form-label">Enter OTP</label>
+    <input type="text" name="otp" class="form-control" required>
+   </div>
+   <button class="btn btn-primary">Verify</button>
+  </form>
+  <?php endif; ?>
+ </div>
+</div>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/task_detail.php
+++ b/task-tracker-oop/task_detail.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__.'/inc/Task.php';
+require_once __DIR__.'/inc/Comment.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: mobile_login.php');
+    exit();
+}
+$taskModel = new Task();
+$commentModel = new Comment();
+$task = $taskModel->find($_GET['id']);
+if (!$task) die('Task not found');
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $commentModel->add($task['id'],$_POST['comment'],$_SESSION['user_id']);
+    header('Location: task_detail.php?id='.$task['id']);
+    exit();
+}
+$comments = $commentModel->forTask($task['id']);
+include __DIR__.'/inc/header.php';
+?>
+<h3><?= htmlspecialchars($task['title']) ?></h3>
+<p>Status: <?= htmlspecialchars($task['status']) ?></p>
+<p>Category: <?= htmlspecialchars($task['category']) ?></p>
+<p><?= nl2br(htmlspecialchars($task['description'])) ?></p>
+<ul class="list-group mt-3">
+<?php foreach($comments as $c): ?>
+<li class="list-group-item"><strong><?= htmlspecialchars($c['name']) ?></strong> (<?= $c['created_at'] ?>)<br><?= htmlspecialchars($c['comment']) ?></li>
+<?php endforeach; ?>
+</ul>
+<form method="post" class="mt-3">
+ <textarea name="comment" class="form-control" placeholder="Add comment"></textarea>
+ <button class="btn btn-primary mt-2">Post</button>
+</form>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/tasks.php
+++ b/task-tracker-oop/tasks.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__.'/inc/Task.php';
+require_once __DIR__.'/inc/Category.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit();
+}
+$taskModel = new Task();
+$catModel = new Category();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $taskModel->create($_POST['title'],$_POST['description'],$_POST['category_id'],$_SESSION['admin_id']);
+}
+$tasks = $taskModel->all();
+$categories = $catModel->all();
+include __DIR__.'/inc/header.php';
+?>
+<h3>Tasks</h3>
+<table class="table table-bordered">
+<tr><th>Title</th><th>Status</th><th>Category</th><th></th></tr>
+<?php foreach($tasks as $t): ?>
+<tr>
+ <td><a href="view_task.php?id=<?= $t['id'] ?>"><?= htmlspecialchars($t['title']) ?></a></td>
+ <td><?= htmlspecialchars($t['status']) ?></td>
+ <td><?= htmlspecialchars($t['category']) ?></td>
+ <td></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<form method="post" class="mt-4">
+ <div class="mb-3">
+  <label class="form-label">Title</label>
+  <input type="text" name="title" class="form-control" required>
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Description</label>
+  <textarea name="description" class="form-control"></textarea>
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Category</label>
+  <select name="category_id" class="form-select">
+   <?php foreach($categories as $c): ?>
+   <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['title']) ?></option>
+   <?php endforeach; ?>
+  </select>
+ </div>
+ <button class="btn btn-primary">Add Task</button>
+</form>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/tasks_list.php
+++ b/task-tracker-oop/tasks_list.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/inc/Task.php';
+require_once __DIR__.'/inc/User.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: mobile_login.php');
+    exit();
+}
+$taskModel = new Task();
+$tasks = $taskModel->userTasks($_SESSION['user_id']);
+include __DIR__.'/inc/header.php';
+?>
+<h3>My Tasks</h3>
+<ul class="list-group">
+<?php foreach($tasks as $t): ?>
+<li class="list-group-item"><a href="task_detail.php?id=<?= $t['id'] ?>"><?= htmlspecialchars($t['title']) ?></a> <span class="badge bg-secondary"><?= htmlspecialchars($t['status']) ?></span></li>
+<?php endforeach; ?>
+</ul>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/view_task.php
+++ b/task-tracker-oop/view_task.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__.'/inc/Task.php';
+require_once __DIR__.'/inc/Comment.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit();
+}
+$taskModel = new Task();
+$commentModel = new Comment();
+$task = $taskModel->find($_GET['id']);
+if (!$task) {
+    die('Task not found');
+}
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $commentModel->add($task['id'],$_POST['comment'],$_SESSION['admin_id']);
+    header('Location: view_task.php?id='.$task['id']);
+    exit();
+}
+$comments = $commentModel->forTask($task['id']);
+include __DIR__.'/inc/header.php';
+?>
+<h3><?= htmlspecialchars($task['title']) ?></h3>
+<p>Status: <strong><?= htmlspecialchars($task['status']) ?></strong></p>
+<p>Category: <?= htmlspecialchars($task['category']) ?></p>
+<p><?= nl2br(htmlspecialchars($task['description'])) ?></p>
+<h4 class="mt-4">Comments</h4>
+<ul class="list-group">
+<?php foreach($comments as $c): ?>
+<li class="list-group-item"><strong><?= htmlspecialchars($c['name']) ?></strong> (<?= $c['created_at'] ?>)<br><?= htmlspecialchars($c['comment']) ?></li>
+<?php endforeach; ?>
+</ul>
+<form method="post" class="mt-3">
+ <textarea name="comment" class="form-control" placeholder="Add comment"></textarea>
+ <button class="btn btn-primary mt-2">Post Comment</button>
+</form>
+<?php include __DIR__.'/inc/footer.php'; ?>


### PR DESCRIPTION
## Summary
- implement object-oriented task tracker module in `task-tracker-oop`
- add bootstrap-based page templates and header menu
- include OTP helper class (placeholder for MSG91 integration)

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_b_687f55f1bb248327993cabd662aa77ed