### PR TITLE
Separate user management form with pagination

### DIFF
--- a/task-tracker-oop/README.md
+++ b/task-tracker-oop/README.md
@@ -8,6 +8,6 @@ This directory contains a simple object-oriented rewrite of the Task Tracker exa
 2. Adjust credentials in `inc/Database.php` if necessary.
 3. Place the folder on a PHP-enabled server and open `login.php` to log in via OTP.
    Admin users are redirected to the dashboard while normal users see their task list.
-4. Once logged in as admin you can manage users from `users.php`, categories from `categories.php` and tasks from `tasks.php`.
+4. Once logged in as admin you can manage users from `users.php` (paginated list) and add/edit via `user_form.php`, categories from `categories.php` and tasks from `tasks.php`.
 
 The MSG91 OTP integration is represented as a placeholder in `inc/Otp.php`.

--- a/task-tracker-oop/inc/User.php
+++ b/task-tracker-oop/inc/User.php
@@ -31,6 +31,20 @@ class User {
         return $stmt->fetchAll();
     }
 
+    public function paginate($page = 1, $perPage = 10) {
+        $offset = ($page - 1) * $perPage;
+        $stmt = $this->db->prepare('SELECT * FROM users ORDER BY id DESC LIMIT ? OFFSET ?');
+        $stmt->bindValue(1, (int)$perPage, PDO::PARAM_INT);
+        $stmt->bindValue(2, (int)$offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll();
+    }
+
+    public function countAll() {
+        $stmt = $this->db->query('SELECT COUNT(*) FROM users');
+        return (int)$stmt->fetchColumn();
+    }
+
     public function update($id, $name, $mobile, $company, $isAdmin, $status) {
         $stmt = $this->db->prepare('UPDATE users SET name=?, mobile=?, company=?, is_admin_login=?, status=? WHERE id=?');
         return $stmt->execute([$name, $mobile, $company, $isAdmin, $status, $id]);

--- a/task-tracker-oop/user_form.php
+++ b/task-tracker-oop/user_form.php
@@ -1,0 +1,66 @@
+<?php
+require_once __DIR__.'/inc/User.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$userModel = new User();
+$id = $_GET['id'] ?? '';
+$editUser = null;
+if ($id) {
+    $editUser = $userModel->findById($id);
+    if (!$editUser) {
+        header('Location: users.php');
+        exit();
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id      = $_POST['id'] ?? '';
+    $name    = $_POST['name'];
+    $mobile  = $_POST['mobile'];
+    $company = $_POST['company'];
+    $isAdmin = $_POST['is_admin'];
+    $status  = isset($_POST['status']) ? 1 : 0;
+    if ($id) {
+        $userModel->update($id,$name,$mobile,$company,$isAdmin,$status);
+    } else {
+        $userModel->create($name,$mobile,$company,$isAdmin);
+    }
+    header('Location: users.php');
+    exit();
+}
+
+include __DIR__.'/inc/header.php';
+?>
+<h3><?= $editUser ? 'Edit User' : 'Add User' ?></h3>
+<form method="post" class="mt-3">
+ <input type="hidden" name="id" value="<?= $editUser['id'] ?? '' ?>">
+ <div class="mb-3">
+  <label class="form-label">Name</label>
+  <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($editUser['name'] ?? '') ?>" required>
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Mobile</label>
+  <input type="text" name="mobile" class="form-control" value="<?= htmlspecialchars($editUser['mobile'] ?? '') ?>" required>
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Company</label>
+  <input type="text" name="company" class="form-control" value="<?= htmlspecialchars($editUser['company'] ?? '') ?>">
+ </div>
+ <div class="mb-3">
+  <label class="form-label">Role</label>
+  <select name="is_admin" class="form-select">
+   <option value="0" <?= isset($editUser) && !$editUser['is_admin_login'] ? 'selected' : '' ?>>User</option>
+   <option value="1" <?= isset($editUser) && $editUser['is_admin_login'] ? 'selected' : '' ?>>Admin</option>
+  </select>
+ </div>
+ <div class="form-check mb-3">
+  <input class="form-check-input" type="checkbox" id="statusCheck" name="status" value="1" <?= !isset($editUser) || ($editUser && $editUser['status']) ? 'checked' : '' ?>>
+  <label class="form-check-label" for="statusCheck">Active</label>
+ </div>
+ <button class="btn btn-primary"><?= $editUser ? 'Update' : 'Add' ?></button>
+ <a href="users.php" class="btn btn-secondary ms-2">Back</a>
+</form>
+<?php include __DIR__.'/inc/footer.php'; ?>

--- a/task-tracker-oop/users.php
+++ b/task-tracker-oop/users.php
@@ -6,7 +6,6 @@ if (!isset($_SESSION['admin_id'])) {
 }
 
 $userModel = new User();
-$editUser = null;
 
 if (isset($_GET['delete'])) {
     $userModel->delete($_GET['delete']);
@@ -20,27 +19,12 @@ if (isset($_GET['toggle'])) {
     exit();
 }
 
-if (isset($_GET['edit'])) {
-    $editUser = $userModel->findById($_GET['edit']);
-}
+$perPage = 10;
+$page    = isset($_GET["page"]) ? max(1,(int)$_GET["page"]) : 1;
+$total   = $userModel->countAll();
+$users   = $userModel->paginate($page, $perPage);
+$totalPages = (int)ceil($total / $perPage);
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $id      = $_POST['id'] ?? '';
-    $name    = $_POST['name'];
-    $mobile  = $_POST['mobile'];
-    $company = $_POST['company'];
-    $isAdmin = $_POST['is_admin'];
-    $status  = isset($_POST['status']) ? 1 : 0;
-    if ($id) {
-        $userModel->update($id,$name,$mobile,$company,$isAdmin,$status);
-    } else {
-        $userModel->create($name,$mobile,$company,$isAdmin);
-    }
-    header('Location: users.php');
-    exit();
-}
-
-$users = $userModel->all();
 include __DIR__.'/inc/header.php';
 ?>
 <h3>Users</h3>
@@ -53,37 +37,23 @@ include __DIR__.'/inc/header.php';
  <td><?= htmlspecialchars($u['company']) ?></td>
  <td><?= $u['is_admin_login'] ? 'Admin' : 'User' ?></td>
  <td><?= $u['status'] ? 'Active' : 'Inactive' ?> (<a href="users.php?toggle=<?= $u['id'] ?>">toggle</a>)</td>
- <td><a href="users.php?edit=<?= $u['id'] ?>">Edit</a> | <a href="users.php?delete=<?= $u['id'] ?>" onclick="return confirm('Delete user?');">Delete</a></td>
+ <td><a href="user_form.php?id=<?= $u['id'] ?>">Edit</a> | <a href="users.php?delete=<?= $u['id'] ?>" onclick="return confirm('Delete user?');">Delete</a></td>
 </tr>
 <?php endforeach; ?>
 </table>
+<div class="mb-3">
+ <a href="user_form.php" class="btn btn-success">Add User</a>
+</div>
+<?php if ($totalPages > 1): ?>
+<nav>
+ <ul class="pagination">
+  <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+   <li class="page-item <?= $i == $page ? 'active' : '' ?>">
+    <a class="page-link" href="?page=<?= $i ?>"><?= $i ?></a>
+   </li>
+  <?php endfor; ?>
+ </ul>
+</nav>
+<?php endif; ?>
 
-<h4><?= $editUser ? 'Edit User' : 'Add User' ?></h4>
-<form method="post" class="mt-3">
- <input type="hidden" name="id" value="<?= $editUser['id'] ?? '' ?>">
- <div class="mb-3">
-  <label class="form-label">Name</label>
-  <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($editUser['name'] ?? '') ?>" required>
- </div>
- <div class="mb-3">
-  <label class="form-label">Mobile</label>
-  <input type="text" name="mobile" class="form-control" value="<?= htmlspecialchars($editUser['mobile'] ?? '') ?>" required>
- </div>
- <div class="mb-3">
-  <label class="form-label">Company</label>
-  <input type="text" name="company" class="form-control" value="<?= htmlspecialchars($editUser['company'] ?? '') ?>">
- </div>
- <div class="mb-3">
-  <label class="form-label">Role</label>
-  <select name="is_admin" class="form-select">
-   <option value="0" <?= isset($editUser) && !$editUser['is_admin_login'] ? 'selected' : '' ?>>User</option>
-   <option value="1" <?= isset($editUser) && $editUser['is_admin_login'] ? 'selected' : '' ?>>Admin</option>
-  </select>
- </div>
- <div class="form-check mb-3">
-  <input class="form-check-input" type="checkbox" id="statusCheck" name="status" value="1" <?= !isset($editUser) || ($editUser && $editUser['status']) ? 'checked' : '' ?>>
-  <label class="form-check-label" for="statusCheck">Active</label>
- </div>
- <button class="btn btn-primary"><?= $editUser ? 'Update' : 'Add' ?></button>
-</form>
 <?php include __DIR__.'/inc/footer.php'; ?>


### PR DESCRIPTION
## Summary
- split user listing and form into separate pages
- add pagination methods to `User` model
- create `user_form.php` for add/edit
- update README

## Testing
- `php -l task-tracker-oop/users.php`
- `php -l task-tracker-oop/user_form.php`
- `find task-tracker-oop -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_b_687f6315dd6c832798a95b5f04dd1d90